### PR TITLE
Update search.json to extend search to the content of the post.

### DIFF
--- a/search.json
+++ b/search.json
@@ -8,7 +8,8 @@ layout: null
       "category" : "{{ post.category }}",
       "tags"     : "{{ post.tags | join: ', ' }}",
       "url"      : "{{ site.baseurl }}{{ post.url }}",
-      "date"     : "{{ post.date | date: '%B %-d, %Y'}}"
+      "date"     : "{{ post.date | date: '%B %-d, %Y'}}",
+      "content"  : "{{ post.content | strip_html | strip_newlines | remove_chars | escape }}"
     } {% unless forloop.last %},{% endunless %}
   {% endfor %}
 ]


### PR DESCRIPTION
Current search finds text in the post titles:

<img width="559" alt="Screenshot 2023-11-06 at 12 41 57" src="https://github.com/JustGoodThemes/BlogBox-Jekyll-Theme/assets/45041451/df8cc3cd-c2e9-48ff-9f9b-727f6000cecf">

But current search does not find text in the body of the post:

<img width="559" alt="Screenshot 2023-11-06 at 12 38 45" src="https://github.com/JustGoodThemes/BlogBox-Jekyll-Theme/assets/45041451/133ac4a2-fa1d-4a23-a345-5d322c902b83">

My branch searches both (for example 'geologically' appears in two posts but not in the titles):

<img width="559" alt="Screenshot 2023-11-06 at 12 38 58" src="https://github.com/JustGoodThemes/BlogBox-Jekyll-Theme/assets/45041451/9602b786-0e55-4eed-a8cf-110837990525">
